### PR TITLE
add support for installing additional python packages and some fixes

### DIFF
--- a/stable/ansible-semaphore/Chart.yaml
+++ b/stable/ansible-semaphore/Chart.yaml
@@ -34,4 +34,4 @@ name: ansible-semaphore
 sources:
 - https://github.com/ansible-semaphore/semaphore
 type: application
-version: 10.0.16
+version: 10.1.0

--- a/stable/ansible-semaphore/README.md
+++ b/stable/ansible-semaphore/README.md
@@ -116,6 +116,7 @@ oidc:
 | oci://registry-1.docker.io/bitnamicharts | postgresql | 15.5.29 |
 
 ## Values
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for the deployment |

--- a/stable/ansible-semaphore/README.md
+++ b/stable/ansible-semaphore/README.md
@@ -155,6 +155,7 @@ oidc:
 | extraInitContainers | list | `[]` | List of extra init containers |
 | extraSidecarContainers | list | `[]` | List of extra sidecar containers |
 | fullnameOverride | string | `""` | Override the fullname |
+| general.additionalPythonPackages | list | `[]` | Additional Python packages to install on launch |
 | general.gitClient | string | `"cmd_git"` | Use Git client implementation |
 | general.host | string | `nil` | Host to access Semaphore |
 | general.maxParallelTasks | int | `0` | Maximum parallel tasks |

--- a/stable/ansible-semaphore/README.md
+++ b/stable/ansible-semaphore/README.md
@@ -116,7 +116,6 @@ oidc:
 | oci://registry-1.docker.io/bitnamicharts | postgresql | 15.5.29 |
 
 ## Values
-
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for the deployment |
@@ -127,6 +126,7 @@ oidc:
 | database.name | string | `"semaphore"` | Name of the used database |
 | database.password | string | `nil` | Password for database |
 | database.passwordKey | string | `"password"` | Key used within secret for password |
+| database.options | object | `{}` | Options for database connection |
 | database.path | string | `"/var/lib/semaphore/database.boltdb"` | Path for the boltdb |
 | database.persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes used for boltdb volume |
 | database.persistence.enabled | bool | `true` | Enable persistence for boltdb |

--- a/stable/ansible-semaphore/templates/configmap.yaml
+++ b/stable/ansible-semaphore/templates/configmap.yaml
@@ -39,3 +39,10 @@ data:
       "ssh_config_path": "{{ .Values.general.sshConfigPath }}",
       "billing_enabled": {{ .Values.billing.enabled }}
     }
+
+  {{- if .Values.general.additionalPythonPackages }}
+  requirements.txt: |
+    {{- range .Values.general.additionalPythonPackages }}
+    {{ . }}
+    {{- end }}
+  {{- end }}

--- a/stable/ansible-semaphore/templates/deployment.yaml
+++ b/stable/ansible-semaphore/templates/deployment.yaml
@@ -111,6 +111,10 @@ spec:
                   name: {{ .Values.database.existingSecret | default (printf "%s-database" (include "ansible-semaphore.fullname" .)) }}
                   key: {{ .Values.database.passwordKey }}
             {{- end }}
+            {{- if .Values.database.options }}
+            - name: SEMAPHORE_DB_OPTIONS
+              value: {{ .Values.database.options | toJson | quote }}
+            {{- end }}
             - name: SEMAPHORE_LDAP_ENABLE
               value: {{ .Values.ldap.enable | quote }}
             {{- if .Values.ldap.enable }}

--- a/stable/ansible-semaphore/templates/deployment.yaml
+++ b/stable/ansible-semaphore/templates/deployment.yaml
@@ -254,6 +254,11 @@ spec:
             - name: boltdb
               mountPath: {{ .Values.database.path | dir }}
             {{- end }}
+            {{- if .Values.general.additionalPythonPackages }}
+            - name: config
+              mountPath: /etc/semaphore/requirements.txt
+              subPath: requirements.txt
+            {{- end }}
         {{- if .Values.extraSidecarContainers }}
         {{- toYaml .Values.extraSidecarContainers | nindent 8 }}
         {{- end }}

--- a/stable/ansible-semaphore/templates/secret.yaml
+++ b/stable/ansible-semaphore/templates/secret.yaml
@@ -22,11 +22,11 @@ data:
   {{- $generalSecretObj := (lookup "v1" "Secret" .Release.Namespace $generalSecretName) | default dict }}
   {{- $generalSecretData := (get $generalSecretObj "data") | default dict }}
   {{- $cookieHash := (get $generalSecretData .Values.secrets.cookieHashKey) | default (randAlphaNum 32 | b64enc | b64enc) }}
-  {{ .Values.secrets.cookieHashKey }}: {{ $cookieHash }}
+  {{ .Values.secrets.cookieHashKey }}: {{ .Values.secrets.cookieHash | default ($cookieHash) }}
   {{- $cookieEncryptionKey := (get $generalSecretData .Values.secrets.cookieEncryptionKey) | default (randAlphaNum 32 | b64enc | b64enc) }}
-  {{ .Values.secrets.cookieEncryptionKey }}: {{ $cookieEncryptionKey }}
+  {{ .Values.secrets.cookieEncryptionKey }}: {{ .Values.secrets.cookieEncryption | default ($cookieEncryptionKey) }}
   {{- $accesskeyEncryptionKey := (get $generalSecretData .Values.secrets.accesskeyEncryptionKey) | default (randAlphaNum 32 | b64enc | b64enc) }}
-  {{ .Values.secrets.accesskeyEncryptionKey }}: {{ $accesskeyEncryptionKey }}
+  {{ .Values.secrets.accesskeyEncryptionKey }}: {{ .Values.secrets.accesskeyEncryption | default ($accesskeyEncryptionKey) }}
 {{- end }}
 {{- if not .Values.runner.existingSecret }}
 ---
@@ -52,7 +52,7 @@ data:
   {{- $runnerSecretObj := (lookup "v1" "Secret" .Release.Namespace $runnerSecretName) | default dict }}
   {{- $runnerSecretData := (get $runnerSecretObj "data") | default dict }}
   {{- $token := (get $runnerSecretData .Values.runner.tokenKey) | default (randAlphaNum 32 | b64enc) }}
-  {{ .Values.runner.tokenKey }}: {{ $token }}
+  {{ .Values.runner.tokenKey }}: {{ .Values.runner.token | default ($token) }}
 {{- end }}
 {{- if and (not .Values.ldap.existingSecret) (.Values.ldap.enable) }}
 ---

--- a/stable/ansible-semaphore/values.yaml
+++ b/stable/ansible-semaphore/values.yaml
@@ -157,6 +157,9 @@ general:
   # -- Path to SSH config
   sshConfigPath: ~/.ssh/config
 
+  # -- Additional Python packages
+  additionalPythonPackages: []
+
 database:
   # -- Type of database backend
   type: bolt

--- a/stable/ansible-semaphore/values.yaml
+++ b/stable/ansible-semaphore/values.yaml
@@ -191,6 +191,9 @@ database:
   # -- Name of the used database
   name: semaphore
 
+  # -- Options for database connection
+  options: {}
+
   # -- Path for the boltdb
   path: /var/lib/semaphore/database.boltdb
 


### PR DESCRIPTION
This PR intends to add support for installing additional Python packages for the Semaphore environment. Some ansible modules to have external dependencies which can be installed that way.

Further changes:

* Add `database.options` to specify additional database driver options. During testing I faced an issue when using the bundled PostgreSQL: Semaphore wouldn't boot up because the postgres server didn't accept SSL and the client was obviously forcing to use SSL. Adding `database.options: {sslmode: "disable"}` has fixed that for me.
* Reuse existing encryption keys/runner token when present. Previously it was re-generating those on every deployment.