### PR TITLE
Prevent unnecessary checksum/config changes

### DIFF
--- a/stable/ansible-semaphore/Chart.yaml
+++ b/stable/ansible-semaphore/Chart.yaml
@@ -34,4 +34,4 @@ name: ansible-semaphore
 sources:
 - https://github.com/ansible-semaphore/semaphore
 type: application
-version: 11.1.6
+version: 11.1.7

--- a/stable/ansible-semaphore/templates/deployment.yaml
+++ b/stable/ansible-semaphore/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       labels:
         {{- include "ansible-semaphore.labels" . | nindent 8 }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ (include (print $.Template.BasePath "/configmap.yaml") . | fromYaml).data | toYaml | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- if  .Values.annotations }}
         {{- toYaml .Values.annotations | nindent 8 }}


### PR DESCRIPTION
We observed unnecessary checksum/config changes because of helm chart version changes.
https://github.com/cloudhippie/charts/blob/master/stable/ansible-semaphore/templates/_helpers.tpl#L37
```yaml
# _helpers.tpl
(...)
{{- define "ansible-semaphore.labels" -}}
helm.sh/chart: "{{ include "ansible-semaphore.chart" . }}"
{{- end }}
(...)
```

https://github.com/cloudhippie/charts/blob/master/stable/ansible-semaphore/templates/configmap.yaml#L8
```yaml
# configmap.yaml
  labels:
    {{- include "ansible-semaphore.labels" . | nindent 4 }}
```

This will result in a new sha256sum for every chart version, which is, from my understanding, not needed.
https://github.com/cloudhippie/charts/blob/master/stable/ansible-semaphore/templates/deployment.yaml#L31C9-L31C24
```yaml
# deployment.yaml
(...)
annotations:
        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
(...)
```