### PR TITLE
Update values.yaml

### DIFF
--- a/stable/ansible-semaphore/values.yaml
+++ b/stable/ansible-semaphore/values.yaml
@@ -203,7 +203,8 @@ database:
   name: semaphore
 
   # -- Options for database connection
-  options: {}
+  options:
+    sslmode: "disable"
 
   # -- Path for the boltdb
   path: /var/lib/semaphore/database.boltdb


### PR DESCRIPTION
database.options.sslmode: "disable"
necessary for postgres functionality in the helm chart 'out of the box'

please consider adding this as a default option as current semaphore image tries to use SSL connecting to PostgreSQL as default but your helm chart install postgres without SSL by default
if for some reason you don't with to do it -please add is as a comment 