### PR TITLE
feat(yopass): add value to toggle automounting of the SA token

### DIFF
--- a/stable/yopass/Chart.yaml
+++ b/stable/yopass/Chart.yaml
@@ -34,4 +34,4 @@ name: yopass
 sources:
 - https://github.com/jhaals/yopass
 type: application
-version: 6.0.0
+version: 6.1.0

--- a/stable/yopass/templates/deployment.yaml
+++ b/stable/yopass/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
 {{- end }}
 
     spec:
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
       serviceAccountName: {{ include "yopass.serviceAccountName" . }}
       {{- if .Values.image.pullSecrets }}
 

--- a/stable/yopass/values.yaml
+++ b/stable/yopass/values.yaml
@@ -31,6 +31,9 @@ serviceAccount:
   # -- Define annotations for the service account
   annotations: {}
 
+  # -- Automount service account token
+  automountToken: false
+
 # -- Updaqte strategy for deployment
 updateStrategy:
   type: Recreate


### PR DESCRIPTION
Hi,

since yopass is not directly interacting with the Kubernetes API, it can be useful to disable the automounting of the respective SA token (Either of the default SA or the one created by this Chart).

Hope the PR itself is fine,
Cheers