### PR TITLE
fix k8s style vars issue, allow quotes, <> etc. in vars

### DIFF
--- a/stable/ansible-semaphore/Chart.yaml
+++ b/stable/ansible-semaphore/Chart.yaml
@@ -34,4 +34,4 @@ name: ansible-semaphore
 sources:
 - https://github.com/ansible-semaphore/semaphore
 type: application
-version: 14.12.1
+version: 14.12.2

--- a/stable/ansible-semaphore/templates/deployment.yaml
+++ b/stable/ansible-semaphore/templates/deployment.yaml
@@ -93,10 +93,10 @@ spec:
                 semaphore user add \
                   --config=/etc/semaphore/config.json \
                   --admin \
-                  --name=$(SEMAPHORE_ADMIN_FULLNAME) \
-                  --login=$(SEMAPHORE_ADMIN_USERNAME) \
-                  --password=$(SEMAPHORE_ADMIN_PASSWORD) \
-                  --email=$(SEMAPHORE_ADMIN_EMAIL)
+                  --name="$SEMAPHORE_ADMIN_FULLNAME" \
+                  --login="$SEMAPHORE_ADMIN_USERNAME" \
+                  --password="$SEMAPHORE_ADMIN_PASSWORD" \
+                  --email="$SEMAPHORE_ADMIN_EMAIL"
               else
                 echo "Admin already extists"
               fi


### PR DESCRIPTION
fix quotation issues by using env vars instead of k8s style search/replace template vars