### PR TITLE
yopass: add optional read-only deployment (-readonly)

### DIFF
--- a/stable/yopass/Chart.yaml
+++ b/stable/yopass/Chart.yaml
@@ -34,4 +34,4 @@ name: yopass
 sources:
 - https://github.com/jhaals/yopass
 type: application
-version: 9.12.0
+version: 9.13.0

--- a/stable/yopass/README.md.gotmpl
+++ b/stable/yopass/README.md.gotmpl
@@ -82,3 +82,90 @@ memcached:
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}
+
+## Read-Only Mode & Split Deployments
+
+Read-only mode disables all secret creation endpoints while keeping retrieval fully functional. This chart can deploy an optional second instance in read-only mode within the same release.
+
+### Enable read-only instance
+
+```yaml
+readOnly:
+  enabled: true
+  ingress:
+    enabled: true
+    hosts:
+      - host: yopass.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+```
+
+Resources created for the read-only instance are suffixed with `-readonly` (Deployment, Service, Ingress). Both instances share the same database configured via `.Values.database.*`.
+
+In read-only mode the server is started with `--read-only`. Endpoint behavior:
+
+| Endpoint | Behavior |
+|----------|----------|
+| `POST /create/secret` | 404 Not Found |
+| `POST /create/file` | 404 Not Found |
+| `GET /secret/{key}` | Active |
+| `GET /file/{key}` | Active |
+| `DELETE /secret/{key}` | Active |
+
+The frontend detects `READ_ONLY: true` from the `/config` endpoint and shows a read-only landing page instead of the create form.
+
+### Split deployment pattern (one release)
+
+Deploy one Helm release with both instances sharing one database:
+
+```yaml
+database:
+  type: memcached
+  dsn: memcached:11211
+
+memcached:
+  enabled: true
+
+ingress:
+  enabled: true
+  hosts:
+    - host: internal.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+readOnly:
+  enabled: true
+  ingress:
+    enabled: true
+    hosts:
+      - host: yopass.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+```
+
+Both instances connect to the same Memcached or Redis database. Secrets created on the internal instance can be retrieved via the public read-only instance.
+
+### OIDC on internal, public read-only
+
+Require authentication only on the internal instance while the public instance remains open for retrieval:
+
+```yaml
+extraEnvVariables:
+  REQUIRE_AUTH: "true"
+  OIDC_ISSUER: https://accounts.google.com
+  OIDC_CLIENT_ID: "123456789-abc.apps.googleusercontent.com"
+  OIDC_CLIENT_SECRET: "GOCSPX-..."
+  OIDC_REDIRECT_URL: https://internal.example.com/auth/callback
+  OIDC_ALLOWED_DOMAIN: example.com
+
+readOnly:
+  enabled: true
+  # no auth variables here
+```
+
+Notes:
+- Deletion of one-time secrets happens automatically via `DELETE /secret/{key}` when a recipient opens a secret; this endpoint remains active in read-only mode intentionally.
+- If you use a CDN or caching layer in front of the public instance, ensure retrieval endpoints (`GET /secret/*`, `GET /file/*`) are not cached.

--- a/stable/yopass/ci/readonly-values.yaml
+++ b/stable/yopass/ci/readonly-values.yaml
@@ -1,0 +1,25 @@
+---
+readOnly:
+  enabled: true
+  ingress:
+    enabled: true
+    hosts:
+      - host: yopass-public.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+
+memcached:
+  enabled: true
+
+ingress:
+  enabled: true
+  hosts:
+    - host: yopass-internal.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+resources: {}
+
+...

--- a/stable/yopass/templates/deployment-readonly.yaml
+++ b/stable/yopass/templates/deployment-readonly.yaml
@@ -1,34 +1,26 @@
+{{- if .Values.readOnly.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 
 metadata:
-  name: {{ include "yopass.fullname" . }}
+  name: {{ include "yopass.fullname" . }}-readonly
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "yopass.labels" . | nindent 4 }}
-{{- with .Values.annotation }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
 
 spec:
-  replicas: {{ .Values.replicaCount }}
-  {{- if .Values.updateStrategy }}
-
-  strategy:
-    {{ toYaml .Values.updateStrategy | nindent 4 }}
-  {{- end }}
+  replicas: {{ default .Values.replicaCount .Values.readOnly.replicaCount }}
 
   selector:
     matchLabels:
       {{- include "yopass.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: internal
+      app.kubernetes.io/component: readonly
 
   template:
     metadata:
       labels:
         {{- include "yopass.labels" . | nindent 8 }}
-        app.kubernetes.io/component: internal
+        app.kubernetes.io/component: readonly
 {{- if  .Values.annotations }}
       annotations:
         {{- toYaml .Values.annotations | nindent 8 }}
@@ -62,7 +54,7 @@ spec:
 
           args:
             - --address=0.0.0.0
-            - --port={{ .Values.service.internalPort }}
+            - --port={{ default .Values.service.internalPort .Values.readOnly.service.internalPort }}
             {{- if .Values.metrics.enabled }}
             - --metrics-port={{ .Values.metrics.internalPort }}
             {{- end }}
@@ -74,34 +66,35 @@ spec:
             - --memcached={{ .Values.database.dsn }}
             {{- end }}
             - --max-length={{ .Values.config.maxLength }}
+            - --read-only
           {{- with .Values.podSecurityContext }}
 
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.extraEnvSecrets .Values.extraEnvVariables }}
+          {{- if or .Values.readOnly.extraEnvSecrets .Values.readOnly.extraEnvVariables }}
 
           env:
-            {{- range $key, $value := .Values.extraEnvSecrets }}
+            {{- range $key, $value := .Values.readOnly.extraEnvSecrets }}
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
                   name: {{ required "Must specify secret!" $value.secret }}
                   key: {{ required "Must specify key!" $value.key }}
             {{- end }}
-            {{- range $key, $value := .Values.extraEnvVariables }}
+            {{- range $key, $value := .Values.readOnly.extraEnvVariables }}
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
           {{- end }}
-          {{- if or .Values.envFromSecrets .Values.envFromConfigMaps }}
+          {{- if or .Values.readOnly.envFromSecrets .Values.readOnly.envFromConfigMaps }}
 
           envFrom:
-          {{- range $name := .Values.envFromSecrets }}
+          {{- range $name := .Values.readOnly.envFromSecrets }}
             - secretRef:
                 name: {{ $name }}
           {{- end }}
-          {{- range $name := .Values.envFromConfigMaps }}
+          {{- range $name := .Values.readOnly.envFromConfigMaps }}
             - configMapRef:
                 name: {{ $name }}
           {{- end }}
@@ -109,7 +102,7 @@ spec:
 
           ports:
             - name: http
-              containerPort: {{ .Values.service.internalPort }}
+              containerPort: {{ default .Values.service.internalPort .Values.readOnly.service.internalPort }}
               protocol: TCP
             {{- if .Values.metrics.enabled }}
             - name: metrics
@@ -126,36 +119,24 @@ spec:
             httpGet:
               path: /
               port: http
-          {{- if .Values.resources }}
+          {{- if (default .Values.resources .Values.readOnly.resources) }}
 
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml (default .Values.resources .Values.readOnly.resources) | nindent 12 }}
           {{- end }}
-          {{- if .Values.extraVolumeMounts }}
-
-          volumeMounts:
-            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
-          {{- end }}
-        {{- if .Values.extraSidecarContainers }}
-        {{- toYaml .Values.extraSidecarContainers | nindent 8 }}
-        {{- end }}
-      {{- if .Values.nodeSelector }}
+      {{- if (default .Values.nodeSelector .Values.readOnly.nodeSelector) }}
 
       nodeSelector:
-        {{ toYaml .Values.nodeSelector | nindent 8 }}
+        {{- toYaml (default .Values.nodeSelector .Values.readOnly.nodeSelector) | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (default .Values.affinity .Values.readOnly.affinity) }}
 
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (default .Values.tolerations .Values.readOnly.tolerations) }}
 
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.extraVolumes }}
-
-      volumes:
-        {{- toYaml .Values.extraVolumes | nindent 8 }}
-      {{- end }}
+{{- end }}

--- a/stable/yopass/templates/deployment.yaml
+++ b/stable/yopass/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 
 metadata:
-  name: {{ include "yopass.fullname" . }}
+  name: {{ include "yopass.fullname" . }}{{ if .Values.readOnly.enabled }}-internal{{ end }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "yopass.labels" . | nindent 4 }}

--- a/stable/yopass/templates/ingress-readonly.yaml
+++ b/stable/yopass/templates/ingress-readonly.yaml
@@ -1,0 +1,50 @@
+{{- if and .Values.readOnly.enabled .Values.readOnly.ingress.enabled -}}
+{{- $serviceName := print (include "yopass.fullname" .) "-readonly" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+
+metadata:
+  name: {{ include "yopass.fullname" . }}-readonly
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "yopass.labels" . | nindent 4 }}
+{{- if .Values.readOnly.ingress.labels }}
+    {{- toYaml .Values.readOnly.ingress.labels | nindent 4 }}
+{{- end }}
+{{- if  .Values.readOnly.ingress.annotations }}
+  annotations:
+    {{- toYaml .Values.readOnly.ingress.annotations | nindent 4 }}
+{{- end }}
+
+spec:
+  {{- if .Values.readOnly.ingress.className }}
+  ingressClassName: {{ .Values.readOnly.ingress.className }}
+  {{- end }}
+  {{- if .Values.readOnly.ingress.tls }}
+  tls:
+    {{- range .Values.readOnly.ingress.tls }}
+    - secretName: {{ .secretName }}
+      {{- if .hosts }}
+      hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.readOnly.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/stable/yopass/templates/ingress.yaml
+++ b/stable/yopass/templates/ingress.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := print (include "yopass.fullname" .) }}
+{{- $serviceName := printf "%s%s" (include "yopass.fullname" .) (ternary "-internal" "" .Values.readOnly.enabled) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
-  name: {{ include "yopass.fullname" . }}
+  name: {{ include "yopass.fullname" . }}{{ if .Values.readOnly.enabled }}-internal{{ end }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "yopass.labels" . | nindent 4 }}

--- a/stable/yopass/templates/service-readonly.yaml
+++ b/stable/yopass/templates/service-readonly.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.readOnly.enabled .Values.readOnly.service.enabled }}
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: {{ template "yopass.fullname" . }}-readonly
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "yopass.labels" . | nindent 4 }}
+{{- if .Values.readOnly.service.labels }}
+    {{- toYaml .Values.readOnly.service.labels | nindent 4 }}
+{{- end }}
+{{- if  .Values.readOnly.service.annotations }}
+  annotations:
+    {{- toYaml .Values.readOnly.service.annotations | nindent 4 }}
+{{- end }}
+
+spec:
+  type: {{ default .Values.service.type .Values.readOnly.service.type }}
+
+  ports:
+    - name: http
+      port: {{ default .Values.service.port .Values.readOnly.service.port }}
+      targetPort: http
+      protocol: TCP
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}
+
+  selector:
+    {{- include "yopass.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: readonly
+{{- end }}

--- a/stable/yopass/templates/service.yaml
+++ b/stable/yopass/templates/service.yaml
@@ -31,3 +31,4 @@ spec:
 
   selector:
     {{- include "yopass.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: internal

--- a/stable/yopass/templates/service.yaml
+++ b/stable/yopass/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 
 metadata:
-  name: {{ template "yopass.fullname" . }}
+  name: {{ template "yopass.fullname" . }}{{ if .Values.readOnly.enabled }}-internal{{ end }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "yopass.labels" . | nindent 4 }}

--- a/stable/yopass/templates/servicemonitor-readonly.yaml
+++ b/stable/yopass/templates/servicemonitor-readonly.yaml
@@ -1,9 +1,9 @@
-{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.readOnly.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 
 metadata:
-  name: {{ include "yopass.fullname" . }}{{ if .Values.readOnly.enabled }}-internal{{ end }}
+  name: {{ include "yopass.fullname" . }}-readonly
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace }}
   labels:
     {{- include "yopass.labels" . | nindent 4 }}
@@ -23,7 +23,7 @@ spec:
   selector:
     matchLabels:
       {{- include "yopass.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: internal
+      app.kubernetes.io/component: readonly
 
   endpoints:
     - path: /metrics

--- a/stable/yopass/templates/tests/test-connection.yaml
+++ b/stable/yopass/templates/tests/test-connection.yaml
@@ -18,4 +18,4 @@ spec:
         - wget
       args:
         - --spider
-        - http://{{ include "yopass.fullname" . }}:{{ .Values.service.port }}
+        - http://{{ include "yopass.fullname" . }}{{ if .Values.readOnly.enabled }}-internal{{ end }}:{{ .Values.service.port }}

--- a/stable/yopass/values.yaml
+++ b/stable/yopass/values.yaml
@@ -206,6 +206,80 @@ config:
   # -- (int) Max length of encrypted secret
   maxLength: 10000
 
+# -- Optional second deployment in read-only mode
+readOnly:
+  # -- Enable rendering a second, read-only instance (resources suffixed with -readonly)
+  enabled: false
+
+  # -- (int) Replicas for the read-only deployment (defaults to .Values.replicaCount)
+  replicaCount:
+
+  # -- List of environment variables from existing secrets for read-only instance
+  envFromSecrets: []
+
+  # -- List of environment variables from existing configmaps for read-only instance
+  envFromConfigMaps: []
+
+  # -- Extra environment variables for read-only instance
+  extraEnvVariables: {}
+
+  # -- Extra environment variables from secrets for read-only instance
+  extraEnvSecrets: {}
+
+  # -- Resources for the read-only deployment (defaults to .Values.resources)
+  resources: {}
+
+  # -- Node selector for the read-only deployment (defaults to .Values.nodeSelector)
+  nodeSelector: {}
+
+  # -- Affinity for the read-only deployment (defaults to .Values.affinity)
+  affinity: {}
+
+  # -- Tolerations for the read-only deployment (defaults to .Values.tolerations)
+  tolerations: []
+
+  service:
+    # -- Enable Service for read-only instance
+    enabled: true
+
+    # -- Type of the read-only service (defaults to .Values.service.type)
+    type:
+
+    # -- (int) Port of the read-only service (defaults to .Values.service.port)
+    port:
+
+    # -- (int) Internal port of the read-only service (defaults to .Values.service.internalPort)
+    internalPort:
+
+    # -- Additional annotations for the read-only service
+    annotations: {}
+
+    # -- Additional labels for the read-only service
+    labels: {}
+
+  ingress:
+    # -- Enable ingress for read-only instance
+    enabled: false
+
+    # -- (string) Class name for the ingress resource
+    className:
+
+    # -- Host definition for read-only ingress
+    hosts:
+      - host: example.local
+        paths:
+          - path: /
+            pathType: Prefix
+
+    # -- Optional TLS configuration for read-only ingress
+    tls: []
+
+    # -- Additional annotations for the read-only ingress
+    annotations: {}
+
+    # -- Additional labels for the read-only ingress
+    labels: {}
+
 # -- Resources for the deployment
 resources:
   limits: {}


### PR DESCRIPTION
- Add .Values.readOnly.* and render second Deployment/Service/Ingress with -readonly suffix
- Add app.kubernetes.io/component labels/selectors to separate internal vs readonly
- Reuse global DB/metrics; keep single ServiceMonitor
- Update README.md.gotmpl with split deployment docs
- Add example values at ci/readonly-values.yaml